### PR TITLE
Issues with deploy via subtree

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -1,4 +1,16 @@
 #!/usr/bin/env sh
 
-# Deploy using Middleman-deploy
-jekyll build && git subtree push --prefix build origin gh-pages
+# Deplo build directory to gh-pages
+sha=`git rev-parse HEAD`
+bundle exec jekyll build
+
+cd build
+
+if [ ! -d ".git" ]; then
+  remote=`git config --get remote.origin.url`
+  git init .
+  git remote add origin $remote
+fi
+
+git add -A && git commit -m "Deploy ${sha}"
+git push origin master:gh-pages


### PR DESCRIPTION
We were just recently trying to deploy with the instructions provided by the README and `bin/deploy`. Unfortunately, since the `build` folder is being ignored from git, `git subtree push --prefix build origin gh-pages` just keeps pushing the last version of build that was ever committed.

Removing `build` from the gitignore resolves this issue. However that doesn't feel like the best solution. I'm not sure what the best solution to resolve this is just yet.
