### PR TITLE
Add `jekyll-assets-autoprefixer`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,7 @@ gem 'jekyll-haml'
 gem 'neat'
 gem 'sass'
 gem 'uglifier'
+
+group :jekyll_plugins do
+  gem 'jekyll-assets-autoprefixer'
+end

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ for projects that may end up as a Ruby on Rails app.
   Write javascript with simpler syntax
 * [Sass](http://sass-lang.com):
   CSS with superpowers
+* [Autoprefixer](https://github.com/postcss/autoprefixer):
+  Add vendor prefixes to CSS
 * [Bourbon](http://bourbon.io):
   Sass mixin library
 * [Neat](http://neat.bourbon.io):


### PR DESCRIPTION
Since vendor prefixing CSS rules has been [deprecated by
Bourbon][deprecated], adds [jekyll-assets-autoprefixer] to starter kit.

[deprecated]: https://github.com/thoughtbot/bourbon/issues/702
[jekyll-assets-autoprefixer]: https://github.com/jekyll-assets/jekyll-assets-autoprefixer